### PR TITLE
feat: load chat rooms on login and sort chat messages

### DIFF
--- a/my-app-front/src/App.css
+++ b/my-app-front/src/App.css
@@ -1,38 +1,329 @@
-.App {
-  text-align: center;
+:root {
+  color-scheme: light dark;
+  font-family: 'Noto Sans KR', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+body {
+  margin: 0;
+  background-color: #f4f6fb;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
+.app {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  color: #1f2933;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  background: linear-gradient(135deg, #29339b, #3b82f6);
+  color: #ffffff;
+  box-shadow: 0 2px 6px rgba(17, 24, 39, 0.15);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.app-content {
+  flex: 1;
+  padding: 2rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.login-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 900px;
+}
+
+.chat-section {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 2rem;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 1.75rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: left;
+}
+
+.input-group span {
+  font-weight: 600;
+}
+
+input[type='text'],
+input[type='password'] {
+  border: 1px solid #d0d7e2;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type='text']:focus,
+input[type='password']:focus {
+  border-color: #3b82f6;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.primary-button,
+.secondary-button {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+}
+
+.primary-button:disabled,
+.secondary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
+}
+
+.primary-button:not(:disabled):hover,
+.secondary-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+}
+
+.secondary-button {
+  background-color: #e2e8f0;
+  color: #1f2933;
+}
+
+.error-text {
+  color: #ef4444;
+  margin: 0;
+}
+
+.helper-text {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.token-card .secondary-button {
+  align-self: flex-start;
+}
+
+.chat-sidebar {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chat-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chat-room-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.chat-room-button {
+  width: 100%;
+  text-align: left;
+  border: 1px solid #e2e8f0;
+  background-color: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.1s ease;
+}
+
+.chat-room-button:hover {
+  background-color: #eef2ff;
+  border-color: #c7d2fe;
+  transform: translateY(-1px);
+}
+
+.chat-room-button.active {
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 12px 20px rgba(79, 70, 229, 0.25);
+}
+
+.room-name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.room-meta {
+  font-size: 0.85rem;
+  color: inherit;
+  opacity: 0.9;
+}
+
+.pagination {
+  display: flex;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  gap: 1rem;
+  margin-top: 0.5rem;
 }
 
-.App-link {
-  color: #61dafb;
+.chat-main {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 540px;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+.chat-main-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.message-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.message-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #cbd5f5;
+}
+
+.message-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.message-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.sender {
+  font-weight: 600;
+}
+
+.message-id {
+  background-color: rgba(99, 102, 241, 0.12);
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+}
+
+.message-content {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1f2933;
+}
+
+.empty-state {
+  text-align: center;
+  color: #94a3b8;
+  padding: 1.5rem;
+  background-color: #f8fafc;
+  border-radius: 0.75rem;
+  border: 1px dashed #cbd5f5;
+}
+
+@media (max-width: 960px) {
+  .chat-section {
+    grid-template-columns: 1fr;
   }
-  to {
-    transform: rotate(360deg);
+
+  .chat-sidebar {
+    max-height: 320px;
+    overflow: hidden;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-content {
+    padding: 1rem;
+  }
+
+  .card,
+  .chat-sidebar,
+  .chat-main {
+    padding: 1.25rem;
   }
 }

--- a/my-app-front/src/App.js
+++ b/my-app-front/src/App.js
@@ -1,23 +1,421 @@
-import logo from './logo.svg';
+import { useCallback, useMemo, useState } from 'react';
 import './App.css';
 
+const DEFAULT_CHAT_ROOM_PAGE_SIZE = 15;
+const DEFAULT_MESSAGE_PAGE_SIZE = 30;
+
 function App() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [tokenInput, setTokenInput] = useState('');
+  const [accessToken, setAccessToken] = useState('');
+  const [loginError, setLoginError] = useState('');
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
+
+  const [chatRooms, setChatRooms] = useState([]);
+  const [chatRoomsPage, setChatRoomsPage] = useState(0);
+  const [chatRoomsTotalPages, setChatRoomsTotalPages] = useState(0);
+  const [chatRoomsError, setChatRoomsError] = useState('');
+  const [isLoadingRooms, setIsLoadingRooms] = useState(false);
+
+  const [selectedRoom, setSelectedRoom] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [messagesError, setMessagesError] = useState('');
+  const [isLoadingMessages, setIsLoadingMessages] = useState(false);
+
+  const isAuthenticated = useMemo(() => Boolean(accessToken), [accessToken]);
+
+  const authHeaders = useMemo(() => {
+    if (!accessToken) {
+      return {};
+    }
+
+    return {
+      Authorization: `Bearer ${accessToken}`,
+    };
+  }, [accessToken]);
+
+  const safeExtract = useCallback((responseBody) => {
+    if (!responseBody) {
+      return [];
+    }
+
+    if (Array.isArray(responseBody)) {
+      return responseBody;
+    }
+
+    if (Array.isArray(responseBody.data)) {
+      return responseBody.data;
+    }
+
+    if (Array.isArray(responseBody.content)) {
+      return responseBody.content;
+    }
+
+    return [];
+  }, []);
+
+  const toSortableId = useCallback((message) => {
+    if (!message) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+
+    const { id } = message;
+
+    if (typeof id === 'number' && Number.isFinite(id)) {
+      return id;
+    }
+
+    const parsed = Number(id);
+
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+
+    return Number.MAX_SAFE_INTEGER;
+  }, []);
+
+  const fetchChatRooms = useCallback(
+    async (page = 0) => {
+      if (!isAuthenticated) {
+        return;
+      }
+
+      setIsLoadingRooms(true);
+      setChatRoomsError('');
+
+      try {
+        const response = await fetch(
+          `/api/chatRooms?page=${page}&size=${DEFAULT_CHAT_ROOM_PAGE_SIZE}`,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              ...authHeaders,
+            },
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error('채팅방 목록을 불러오지 못했습니다.');
+        }
+
+        const responseBody = await response.json();
+        const rooms = safeExtract(responseBody);
+
+        setChatRooms(Array.isArray(rooms) ? rooms : []);
+        setChatRoomsPage(responseBody.number ?? page ?? 0);
+        setChatRoomsTotalPages(responseBody.totalPages ?? 0);
+      } catch (error) {
+        setChatRooms([]);
+        setChatRoomsError(error.message ?? '채팅방 목록을 불러오지 못했습니다.');
+      } finally {
+        setIsLoadingRooms(false);
+      }
+    },
+    [authHeaders, isAuthenticated, safeExtract]
+  );
+
+  const fetchMessages = useCallback(
+    async (roomId, page = 0) => {
+      if (!isAuthenticated || !roomId) {
+        return;
+      }
+
+      setIsLoadingMessages(true);
+      setMessagesError('');
+
+      try {
+        const response = await fetch(
+          `/api/chatRooms/${roomId}/messages?page=${page}&size=${DEFAULT_MESSAGE_PAGE_SIZE}`,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              ...authHeaders,
+            },
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error('채팅 메시지를 불러오지 못했습니다.');
+        }
+
+        const responseBody = await response.json();
+        const payloads = safeExtract(responseBody);
+
+        const sortedMessages = Array.isArray(payloads)
+          ? [...payloads].sort((a, b) => toSortableId(a) - toSortableId(b))
+          : [];
+
+        setMessages(sortedMessages);
+      } catch (error) {
+        setMessages([]);
+        setMessagesError(error.message ?? '채팅 메시지를 불러오지 못했습니다.');
+      } finally {
+        setIsLoadingMessages(false);
+      }
+    },
+    [authHeaders, isAuthenticated, safeExtract, toSortableId]
+  );
+
+  const handleLogin = useCallback(
+    async (event) => {
+      event.preventDefault();
+
+      if (!username || !password) {
+        setLoginError('아이디와 비밀번호를 모두 입력해주세요.');
+        return;
+      }
+
+      setIsLoggingIn(true);
+      setLoginError('');
+
+      try {
+        const response = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ username, password }),
+        });
+
+        if (!response.ok) {
+          throw new Error('로그인에 실패했습니다.');
+        }
+
+        const data = await response.json();
+        const nextToken = data?.accessToken ?? data?.token ?? data?.Authorization ?? '';
+
+        if (!nextToken) {
+          throw new Error('응답에서 토큰을 찾을 수 없습니다.');
+        }
+
+        setAccessToken(nextToken);
+        setTokenInput(nextToken);
+        await fetchChatRooms(0);
+      } catch (error) {
+        setAccessToken('');
+        setLoginError(error.message ?? '로그인에 실패했습니다.');
+      } finally {
+        setIsLoggingIn(false);
+      }
+    },
+    [fetchChatRooms, password, username]
+  );
+
+  const handleApplyToken = useCallback(() => {
+    if (!tokenInput) {
+      setAccessToken('');
+      setChatRooms([]);
+      setSelectedRoom(null);
+      return;
+    }
+
+    setAccessToken(tokenInput);
+    fetchChatRooms(0);
+  }, [fetchChatRooms, tokenInput]);
+
+  const handleLogout = useCallback(() => {
+    setAccessToken('');
+    setTokenInput('');
+    setUsername('');
+    setPassword('');
+    setChatRooms([]);
+    setSelectedRoom(null);
+    setMessages([]);
+  }, []);
+
+  const handleSelectRoom = useCallback(
+    (room) => {
+      setSelectedRoom(room);
+      if (room?.roomId) {
+        fetchMessages(room.roomId, 0);
+      }
+    },
+    [fetchMessages]
+  );
+
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
+    <div className="app">
+      <header className="app-header">
+        <h1>Festival Chat</h1>
+        {isAuthenticated && (
+          <button type="button" className="secondary-button" onClick={handleLogout}>
+            로그아웃
+          </button>
+        )}
       </header>
+
+      <main className="app-content">
+        {!isAuthenticated && (
+          <section className="login-section">
+            <form className="card" onSubmit={handleLogin}>
+              <h2>로그인</h2>
+              <label className="input-group">
+                <span>아이디</span>
+                <input
+                  type="text"
+                  value={username}
+                  onChange={(event) => setUsername(event.target.value)}
+                  placeholder="아이디를 입력하세요"
+                />
+              </label>
+              <label className="input-group">
+                <span>비밀번호</span>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  placeholder="비밀번호를 입력하세요"
+                />
+              </label>
+              {loginError && <p className="error-text">{loginError}</p>}
+              <button type="submit" className="primary-button" disabled={isLoggingIn}>
+                {isLoggingIn ? '로그인 중...' : '로그인'}
+              </button>
+            </form>
+
+            <div className="card token-card">
+              <h2>토큰 직접 입력</h2>
+              <p className="helper-text">이미 발급받은 토큰이 있다면 아래에 붙여넣어 주세요.</p>
+              <input
+                type="text"
+                value={tokenInput}
+                onChange={(event) => setTokenInput(event.target.value)}
+                placeholder="예: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+              />
+              <button type="button" className="secondary-button" onClick={handleApplyToken}>
+                토큰 적용
+              </button>
+            </div>
+          </section>
+        )}
+
+        {isAuthenticated && (
+          <section className="chat-section">
+            <div className="chat-sidebar">
+              <div className="chat-sidebar-header">
+                <h2>채팅방</h2>
+                <button
+                  type="button"
+                  className="secondary-button"
+                  onClick={() => fetchChatRooms(chatRoomsPage)}
+                  disabled={isLoadingRooms}
+                >
+                  {isLoadingRooms ? '불러오는 중...' : '새로고침'}
+                </button>
+              </div>
+
+              {chatRoomsError && <p className="error-text">{chatRoomsError}</p>}
+
+              <ul className="chat-room-list">
+                {chatRooms.length === 0 && !isLoadingRooms && (
+                  <li className="empty-state">열려 있는 채팅방이 없습니다.</li>
+                )}
+                {chatRooms.map((room) => (
+                  <li key={room.roomId ?? room.id}>
+                    <button
+                      type="button"
+                      className={
+                        selectedRoom?.roomId === (room.roomId ?? room.id)
+                          ? 'chat-room-button active'
+                          : 'chat-room-button'
+                      }
+                      onClick={() => handleSelectRoom(room)}
+                    >
+                      <span className="room-name">{room.roomName ?? '이름 없는 채팅방'}</span>
+                      <span className="room-meta">
+                        #{room.roomId ?? room.id}
+                        {room.festivalId ? ` · Festival ${room.festivalId}` : ''}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+
+              {chatRoomsTotalPages > 1 && (
+                <div className="pagination">
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    onClick={() => {
+                      const previousPage = Math.max(chatRoomsPage - 1, 0);
+                      fetchChatRooms(previousPage);
+                    }}
+                    disabled={isLoadingRooms || chatRoomsPage <= 0}
+                  >
+                    이전
+                  </button>
+                  <span>
+                    {chatRoomsPage + 1} / {chatRoomsTotalPages}
+                  </span>
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    onClick={() => {
+                      const nextPage = Math.min(chatRoomsPage + 1, chatRoomsTotalPages - 1);
+                      fetchChatRooms(nextPage);
+                    }}
+                    disabled={
+                      isLoadingRooms || chatRoomsPage >= chatRoomsTotalPages - 1 || chatRoomsTotalPages === 0
+                    }
+                  >
+                    다음
+                  </button>
+                </div>
+              )}
+            </div>
+
+            <div className="chat-main">
+              {selectedRoom ? (
+                <>
+                  <div className="chat-main-header">
+                    <div>
+                      <h2>{selectedRoom.roomName ?? '선택된 채팅방'}</h2>
+                      <p className="helper-text">채팅은 메시지 ID 기준으로 오름차순 정렬됩니다.</p>
+                    </div>
+                    <button
+                      type="button"
+                      className="secondary-button"
+                      onClick={() => fetchMessages(selectedRoom.roomId ?? selectedRoom.id, 0)}
+                      disabled={isLoadingMessages}
+                    >
+                      {isLoadingMessages ? '불러오는 중...' : '새로고침'}
+                    </button>
+                  </div>
+
+                  {messagesError && <p className="error-text">{messagesError}</p>}
+
+                  <ul className="message-list">
+                    {messages.length === 0 && !isLoadingMessages && (
+                      <li className="empty-state">표시할 채팅 메시지가 없습니다.</li>
+                    )}
+                    {messages.map((message) => (
+                      <li key={message.id ?? `${message.senderName}-${message.content}`} className="message-item">
+                        {message.profileImgUrl && (
+                          <img
+                            className="avatar"
+                            src={message.profileImgUrl}
+                            alt={`${message.senderName ?? '사용자'} 프로필`}
+                          />
+                        )}
+                        <div className="message-body">
+                          <div className="message-meta">
+                            <span className="sender">{message.senderName ?? '알 수 없음'}</span>
+                            <span className="message-id">ID {message.id ?? '-'}</span>
+                          </div>
+                          <p className="message-content">{message.content ?? ''}</p>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              ) : (
+                <div className="empty-state">좌측에서 채팅방을 선택하세요.</div>
+              )}
+            </div>
+          </section>
+        )}
+      </main>
     </div>
   );
 }

--- a/my-app-front/src/App.test.js
+++ b/my-app-front/src/App.test.js
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login form and helper text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  expect(screen.getByRole('heading', { name: /festival chat/i })).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: /로그인/i })).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/아이디를 입력하세요/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /로그인/ })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- build a login/token flow that immediately fetches the available chat rooms from the updated endpoints
- show chat messages ordered by their message id with refresh controls and improved empty states
- refresh the chat interface styling and update the smoke test to reflect the new login screen

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d3bebf1fb483288a6dbc9a5a6d0b01