### PR TITLE
Update chat panel for new chat endpoints and sorting

### DIFF
--- a/my-app-front/src/App.css
+++ b/my-app-front/src/App.css
@@ -121,6 +121,66 @@ textarea {
   margin: 1rem 0;
 }
 
+.chat-room-section {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat-room-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.chat-room-status {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.chat-room-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat-room-item {
+  margin: 0;
+}
+
+.chat-room-button {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  color: #1f2933;
+  box-shadow: none;
+}
+
+.chat-room-button.active {
+  border-color: #6366f1;
+  background-color: #eef2ff;
+  color: #312e81;
+}
+
+.chat-room-title {
+  font-weight: 600;
+}
+
+.chat-room-meta {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
 .message-list {
   margin-top: 1.5rem;
   display: flex;

--- a/my-app-front/src/ChatRoomPanel.js
+++ b/my-app-front/src/ChatRoomPanel.js
@@ -1,6 +1,6 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BACKEND_BASE_URL } from './config';
-import { fetchMessages, getOrCreateChatRoom } from './api';
+import { fetchChatRooms, fetchMessages, getOrCreateChatRoom } from './api';
 import { SimpleStompClient } from './simpleStompClient';
 
 function buildWebSocketUrl() {
@@ -17,18 +17,106 @@ function buildWebSocketUrl() {
   }
 }
 
+const DEFAULT_MESSAGE_PAGE_SIZE = 30;
+
+function coerceMessageId(message) {
+  if (!message || message.id === undefined || message.id === null) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  if (typeof message.id === 'number' && Number.isFinite(message.id)) {
+    return message.id;
+  }
+  const parsed = Number(message.id);
+  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+}
+
+function sortMessagesById(messages) {
+  return [...messages].sort((a, b) => coerceMessageId(a) - coerceMessageId(b));
+}
+
+function mergeMessagesById(existing, incoming) {
+  const map = new Map();
+
+  existing.forEach((message, index) => {
+    if (!message) {
+      return;
+    }
+    const key = message.id ?? `existing-${index}`;
+    map.set(String(key), message);
+  });
+
+  incoming.forEach((message, index) => {
+    if (!message) {
+      return;
+    }
+    const key = message.id ?? `incoming-${index}`;
+    map.set(String(key), message);
+  });
+
+  return sortMessagesById(Array.from(map.values()));
+}
+
 export default function ChatRoomPanel({ accessToken, onLogout }) {
   const [festivalIdInput, setFestivalIdInput] = useState('');
   const [chatRoomId, setChatRoomId] = useState(null);
   const [messages, setMessages] = useState([]);
-  const [page, setPage] = useState(0);
+  const [messagePage, setMessagePage] = useState(0);
   const [statusMessage, setStatusMessage] = useState('');
   const [connectionStatus, setConnectionStatus] = useState('disconnected');
   const [newMessage, setNewMessage] = useState('');
+  const [chatRooms, setChatRooms] = useState([]);
+  const [chatRoomsMessage, setChatRoomsMessage] = useState('');
+  const [isLoadingChatRooms, setIsLoadingChatRooms] = useState(false);
   const clientRef = useRef(null);
   const subscriptionRef = useRef(null);
 
   const websocketUrl = useMemo(() => buildWebSocketUrl(), []);
+
+  const refreshChatRooms = useCallback(async () => {
+    if (!accessToken) {
+      return;
+    }
+    setIsLoadingChatRooms(true);
+    setChatRoomsMessage('채팅방 목록을 불러오는 중입니다...');
+    try {
+      const data = await fetchChatRooms({ page: 0, size: 15, accessToken });
+      const rooms = Array.isArray(data?.content)
+        ? [...data.content].sort((a, b) => {
+            const idA = typeof a?.roomId === 'number' ? a.roomId : Number(a?.roomId);
+            const idB = typeof b?.roomId === 'number' ? b.roomId : Number(b?.roomId);
+            if (Number.isFinite(idA) && Number.isFinite(idB)) {
+              return idA - idB;
+            }
+            return 0;
+          })
+        : [];
+      setChatRooms(rooms);
+      if (rooms.length === 0) {
+        setChatRoomsMessage('현재 참여 중인 채팅방이 없습니다. 축제 ID로 새 채팅방을 만들어보세요.');
+      } else {
+        setChatRoomsMessage(`총 ${rooms.length}개의 채팅방을 확인했습니다. 목록에서 대화를 시작할 방을 선택하세요.`);
+      }
+    } catch (error) {
+      setChatRooms([]);
+      setChatRoomsMessage(error.message);
+    } finally {
+      setIsLoadingChatRooms(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    if (!accessToken) {
+      setChatRooms([]);
+      setChatRoomsMessage('');
+      setChatRoomId(null);
+      setMessages([]);
+      setMessagePage(0);
+      setStatusMessage('');
+      return;
+    }
+
+    refreshChatRooms();
+  }, [accessToken, refreshChatRooms]);
 
   useEffect(() => {
     if (!chatRoomId || !accessToken) {
@@ -43,10 +131,10 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
       { Authorization: `Bearer ${accessToken}` },
       () => {
         setConnectionStatus('connected');
-        subscriptionRef.current = client.subscribe(`/sub/messages/${chatRoomId}`, (body) => {
+        subscriptionRef.current = client.subscribe(`/sub/${chatRoomId}/messages`, (body) => {
           try {
             const payload = JSON.parse(body);
-            setMessages((prev) => [payload, ...prev]);
+            setMessages((prev) => mergeMessagesById(prev, [payload]));
           } catch (error) {
             console.warn('Failed to parse incoming message', error);
           }
@@ -63,9 +151,43 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
         subscriptionRef.current = null;
       }
       client.disconnect();
+      clientRef.current = null;
       setConnectionStatus('disconnected');
     };
   }, [chatRoomId, accessToken, websocketUrl]);
+
+  const openChatRoom = useCallback(async (roomId) => {
+    if (!roomId || !accessToken) {
+      return;
+    }
+
+    setChatRoomId((prev) => {
+      if (prev === roomId) {
+        return prev;
+      }
+      return null;
+    });
+    setStatusMessage('채팅 메시지를 불러오는 중입니다...');
+    setMessages([]);
+    setMessagePage(0);
+
+    try {
+      const payloads = await fetchMessages({ chatRoomId: roomId, page: 0, size: DEFAULT_MESSAGE_PAGE_SIZE, accessToken });
+      setChatRoomId(roomId);
+      setMessages(mergeMessagesById([], payloads));
+      setMessagePage(1);
+      setStatusMessage(`채팅방 #${roomId}을 열었습니다. 최근 ${payloads.length}개의 메시지를 확인했습니다.`);
+    } catch (error) {
+      setStatusMessage(error.message);
+    }
+  }, [accessToken]);
+
+  const handleSelectChatRoom = async (roomId) => {
+    if (roomId === chatRoomId) {
+      return;
+    }
+    await openChatRoom(roomId);
+  };
 
   const handleCreateRoom = async (event) => {
     event.preventDefault();
@@ -77,11 +199,9 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
     try {
       setStatusMessage('채팅방을 준비하는 중입니다...');
       const roomId = await getOrCreateChatRoom({ festivalId: festivalIdInput.trim(), accessToken });
-      setChatRoomId(roomId);
-      const payloads = await fetchMessages({ chatRoomId: roomId, page: 0, size: 30, accessToken });
-      setMessages(payloads);
-      setPage(1);
-      setStatusMessage(`채팅방 #${roomId} 준비가 완료되었습니다. 최근 ${payloads.length}개의 메시지를 불러왔습니다.`);
+      await refreshChatRooms();
+      await openChatRoom(roomId);
+      setStatusMessage((prev) => prev || `채팅방 #${roomId} 준비가 완료되었습니다.`);
     } catch (error) {
       setStatusMessage(error.message);
     }
@@ -95,10 +215,10 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
 
     try {
       setStatusMessage('이전 메시지를 불러오는 중입니다...');
-      const nextPage = page;
-      const payloads = await fetchMessages({ chatRoomId, page: nextPage, size: 30, accessToken });
-      setMessages((prev) => [...prev, ...payloads]);
-      setPage(nextPage + 1);
+      const nextPage = messagePage;
+      const payloads = await fetchMessages({ chatRoomId, page: nextPage, size: DEFAULT_MESSAGE_PAGE_SIZE, accessToken });
+      setMessages((prev) => mergeMessagesById(prev, payloads));
+      setMessagePage(nextPage + 1);
       setStatusMessage(`${payloads.length}개의 메시지를 불러왔습니다.`);
     } catch (error) {
       setStatusMessage(error.message);
@@ -112,7 +232,7 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
     }
 
     try {
-      clientRef.current.send(`/pub/messages/${chatRoomId}`, JSON.stringify({ chatRoomId, content: newMessage.trim() }), {
+      clientRef.current.send(`/pub/${chatRoomId}/messages`, JSON.stringify({ content: newMessage.trim() }), {
         Authorization: `Bearer ${accessToken}`,
       });
       setNewMessage('');
@@ -131,6 +251,30 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
       <p className="card-description">
         축제 ID로 채팅방을 생성하거나 기존 방을 찾아 메시지를 주고받을 수 있습니다. 실시간 통신은 WebSocket과 STOMP 프로토콜을 사용합니다.
       </p>
+
+      <div className="chat-room-section">
+        <div className="chat-room-section-header">
+          <h3>열려 있는 채팅방</h3>
+          <button type="button" className="secondary" onClick={refreshChatRooms} disabled={isLoadingChatRooms}>
+            목록 새로고침
+          </button>
+        </div>
+        {chatRoomsMessage && <p className="chat-room-status">{chatRoomsMessage}</p>}
+        <ul className="chat-room-list">
+          {chatRooms.map((room) => (
+            <li key={room.roomId} className="chat-room-item">
+              <button
+                type="button"
+                className={`chat-room-button ${room.roomId === chatRoomId ? 'active' : ''}`}
+                onClick={() => handleSelectChatRoom(room.roomId)}
+              >
+                <span className="chat-room-title">{room.roomName || `채팅방 #${room.roomId}`}</span>
+                <span className="chat-room-meta">축제 ID: {room.festivalId ?? '정보 없음'}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
 
       <form className="form" onSubmit={handleCreateRoom}>
         <label htmlFor="festivalId">축제 ID</label>
@@ -173,7 +317,7 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
       <div className="message-list">
         {messages.length === 0 && <p className="empty-state">표시할 메시지가 없습니다. 먼저 불러오기 버튼을 눌러보세요.</p>}
         {messages.map((message, index) => (
-          <div key={`${message.senderName}-${index}`} className="message-item">
+          <div key={message.id ?? `${message.senderName ?? 'unknown'}-${index}`} className="message-item">
             <div className="message-header">
               <span className="sender">{message.senderName || '알 수 없음'}</span>
               {message.profileImgUrl && <img src={message.profileImgUrl} alt={message.senderName} className="avatar" />}

--- a/my-app-front/src/api.js
+++ b/my-app-front/src/api.js
@@ -49,7 +49,7 @@ export async function logout(accessToken) {
 }
 
 export async function getOrCreateChatRoom({ festivalId, accessToken }) {
-  const response = await fetch(`${BACKEND_BASE_URL}/api/festivals/${festivalId}/messages`, {
+  const response = await fetch(`${BACKEND_BASE_URL}/api/festivals/${festivalId}/chatRooms`, {
     method: 'POST',
     credentials: 'include',
     headers: {
@@ -69,7 +69,7 @@ export async function getOrCreateChatRoom({ festivalId, accessToken }) {
 
 export async function fetchMessages({ chatRoomId, page = 0, size = 30, accessToken }) {
   const params = new URLSearchParams({ page: String(page), size: String(size) });
-  const response = await fetch(`${BACKEND_BASE_URL}/api/messages/${chatRoomId}?${params.toString()}`, {
+  const response = await fetch(`${BACKEND_BASE_URL}/api/chatRooms/${chatRoomId}/messages?${params.toString()}`, {
     method: 'GET',
     credentials: 'include',
     headers: {
@@ -84,4 +84,23 @@ export async function fetchMessages({ chatRoomId, page = 0, size = 30, accessTok
 
   const data = await handleJsonResponse(response);
   return data.content;
+}
+
+export async function fetchChatRooms({ page = 0, size = 15, accessToken }) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) });
+  const response = await fetch(`${BACKEND_BASE_URL}/api/chatRooms?${params.toString()}`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = await handleJsonResponse(response);
+    throw new Error(errorBody?.message || '채팅방 목록 조회에 실패했습니다.');
+  }
+
+  const data = await handleJsonResponse(response);
+  return data;
 }


### PR DESCRIPTION
## Summary
- align chat API calls with the backend changes, including the new chat room listing endpoint
- show the user’s available chat rooms after login and allow selecting a room before loading messages
- ensure incoming and historical messages are merged and ordered by their payload id while updating WebSocket destinations and styling

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d3c3ebe9dc83288643601371cce61e