### PR TITLE
Allow blank chat messages and show validation errors

### DIFF
--- a/my-app-front/src/App.css
+++ b/my-app-front/src/App.css
@@ -299,6 +299,58 @@ textarea {
   color: #1d4ed8;
 }
 
+.error-popup-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.error-popup {
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  max-width: 420px;
+  width: 100%;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.error-popup h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #111827;
+}
+
+.error-popup p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.error-popup ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #b91c1c;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.error-popup li {
+  line-height: 1.4;
+}
+
+.error-popup button {
+  align-self: flex-end;
+}
+
 @media (max-width: 768px) {
   .container {
     padding: 2rem 1rem 3rem;


### PR DESCRIPTION
## Summary
- allow chat messages to be sent without client-side trimming so validation can be exercised
- subscribe to the user error queue and surface validation messages in a modal popup
- add styling for the validation error popup overlay

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d550cfc42483288c363f2427f6872a