### PR TITLE
Update chat client read handling for new backend behavior

### DIFF
--- a/my-app-front/src/ChatRoomPanel.js
+++ b/my-app-front/src/ChatRoomPanel.js
@@ -560,18 +560,6 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
     }
   }, [setStatusMessage]);
 
-  const sendReadReceipt = useCallback((roomId) => {
-    const client = clientRef.current;
-    if (!client || !roomId) {
-      return;
-    }
-    try {
-      client.send(`/pub/${roomId}/read`, JSON.stringify({}));
-    } catch (error) {
-      console.warn('Failed to send read receipt', error);
-    }
-  }, []);
-
   const refreshChatRooms = useCallback(async () => {
     if (!accessToken) {
       return;
@@ -730,7 +718,6 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
               return room;
             }),
           );
-          sendReadReceipt(notifiedRoomId);
           setStatusMessage(`채팅방 #${notifiedRoomId}에서 들어온 새 메시지를 읽음 처리했습니다.`);
           return;
         }
@@ -763,7 +750,7 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
         console.warn('Failed to process unread notification', error);
       }
     },
-    [chatRoomId, refreshChatRooms, sendReadReceipt],
+    [chatRoomId, refreshChatRooms],
   );
 
   useEffect(() => {
@@ -970,12 +957,11 @@ export default function ChatRoomPanel({ accessToken, onLogout }) {
           return room;
         }),
       );
-      sendReadReceipt(roomId);
       setStatusMessage(`채팅방 #${roomId}을 열었습니다. 최근 ${payloads.length}개의 메시지를 확인했습니다.`);
     } catch (error) {
       setStatusMessage(error.message);
     }
-  }, [getRoomToken, sendReadReceipt]);
+  }, [getRoomToken]);
 
   const handleSelectChatRoom = async (roomId) => {
     if (roomId === chatRoomId) {

--- a/my-app-front/src/simpleStompClient.js
+++ b/my-app-front/src/simpleStompClient.js
@@ -154,9 +154,9 @@ export class SimpleStompClient {
           this.onConnect(frame);
         } else if (frame.command === 'MESSAGE') {
           const subscription = frame.headers.subscription;
-          const handler = this.subscriptions.get(subscription);
-          if (handler) {
-            handler(frame.body, frame);
+          const entry = this.subscriptions.get(subscription);
+          if (entry && typeof entry.callback === 'function') {
+            entry.callback(frame.body, frame);
           }
         } else if (frame.command === 'ERROR') {
           this.onError(frame);
@@ -185,7 +185,7 @@ export class SimpleStompClient {
       destination,
       ack: 'auto',
     });
-    this.subscriptions.set(id, callback);
+    this.subscriptions.set(id, { callback, destination });
     return id;
   }
 
@@ -193,7 +193,12 @@ export class SimpleStompClient {
     if (!this.socket || !this.subscriptions.has(id)) {
       return;
     }
-    this.queueFrame('UNSUBSCRIBE', { id });
+    const { destination } = this.subscriptions.get(id) || {};
+    const headers = { id };
+    if (destination) {
+      headers.destination = destination;
+    }
+    this.queueFrame('UNSUBSCRIBE', headers);
     this.subscriptions.delete(id);
   }
 


### PR DESCRIPTION
## Summary
- stop sending manual read receipt frames now that the server marks rooms as read on subscribe/unsubscribe
- attach the destination header to STOMP unsubscribe frames so the backend can identify the subscription

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68fd5bc7bb94832888316bd10a831765